### PR TITLE
Iwantpinyin

### DIFF
--- a/R/regioncode.R
+++ b/R/regioncode.R
@@ -32,12 +32,12 @@
 #'
 #' @examples
 #'
-#' # library(regioncode)
+#'  # library(regioncode)
 #'
 #'
-#' # regioncode(data_input = corruption$prefecture_id,
-#' #            year_from = 2019,
-#' #           year_to = 1999)
+#'  # regioncode(data_input = corruption$prefecture_id,
+#'             year_from = 2019,
+#'            year_to = 1999)
 #'
 #'
 #' @export
@@ -254,5 +254,8 @@ regioncode <- function(data_input,
     pull(!!year_to)
 
   return(data_output)
-  }
+}
+
+
+
 

--- a/R/regioncode.R
+++ b/R/regioncode.R
@@ -32,10 +32,10 @@
 #'
 #' @examples
 #'
-#'  # library(regioncode)
+#'#  library(regioncode)
 #'
 #'
-#'  # regioncode(data_input = corruption$prefecture_id,
+#'#  regioncode(data_input = corruption$prefecture_id,
 #'             year_from = 2019,
 #'            year_to = 1999)
 #'
@@ -90,11 +90,6 @@ regioncode <- function(data_input,
           year_to <- "prov_language"
           c(year_from,year_to)})
     }else{
-      if (method == 'code2code')
-        stop(
-          "Invalid input: there is no provincial level code converting. You may want to set the argument `province` to FALSE."
-        )
-
       prov_table <- region_table %>%
         select(prov_code:`1999_nickname`) %>%
         distinct


### PR DESCRIPTION
删除了code2code的一个warning，因为现在能选择的method只包括了2code, 2name, 2area, abbre2code, abbre2name, abbre2area, 不需要再额外添加一个关于这个的warning了